### PR TITLE
use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/fastly_to_graphite.php
+++ b/fastly_to_graphite.php
@@ -31,7 +31,7 @@ function getStatsJSON($service_id) {
 
     $opts = array(
         'http' => array('method' => 'GET',
-                        'header' => "X-Fastly-Key: " . FASTLY_KEY . "\r\n"
+                        'header' => "Fastly-Key: " . FASTLY_KEY . "\r\n"
                     )
                 );
 


### PR DESCRIPTION
The use of `X-Fastly-Key` is deprecated and will not be supported long term. This branch replaces any occurrences of `X-Fastly-Key` with `Fastly-Key`.
